### PR TITLE
Added proxy generic settings

### DIFF
--- a/src/WebDriver/Behat/WebDriverExtension/ContextInitializer.php
+++ b/src/WebDriver/Behat/WebDriverExtension/ContextInitializer.php
@@ -5,6 +5,7 @@ namespace WebDriver\Behat\WebDriverExtension;
 use Behat\Behat\Context\ContextInterface;
 use Behat\Behat\Context\Initializer\InitializerInterface;
 use WebDriver\Behat\AbstractWebDriverContext;
+use WebDriver\Capabilities;
 use WebDriver\Client;
 
 class ContextInitializer implements InitializerInterface
@@ -14,13 +15,15 @@ class ContextInitializer implements InitializerInterface
     protected $browserName;
     protected $browser;
     protected $timeout;
+    protected $proxy;
 
-    public function __construct(Client $client, $baseUrl, $browserName = 'firefox', $timeout = 5000)
+    public function __construct(Client $client, $baseUrl, $browserName = 'firefox', $timeout = 5000, $proxy = null)
     {
         $this->client      = $client;
         $this->baseUrl     = $baseUrl;
         $this->browserName = $browserName;
         $this->timeout     = $timeout;
+        $this->proxy   = $proxy;
     }
 
     public function supports(ContextInterface $context)
@@ -48,6 +51,8 @@ class ContextInitializer implements InitializerInterface
 
     private function getCapabilities()
     {
-        return $this->browserName;
+        $capabilities = new Capabilities($this->browserName);
+        $capabilities->proxy = $this->proxy;
+        return $capabilities;
     }
 }

--- a/src/WebDriver/Behat/WebDriverExtension/Extension.php
+++ b/src/WebDriver/Behat/WebDriverExtension/Extension.php
@@ -28,6 +28,7 @@ class Extension implements ExtensionInterface
         $container->setParameter('behat.webdriver.base_url', $config['base_url']);
         $container->setParameter('behat.webdriver.browser', $config['browser']);
         $container->setParameter('behat.webdriver.timeout', $config['timeout']);
+        $container->setParameter('behat.webdriver.proxy', $config['proxy']);
     }
 
     /**
@@ -48,6 +49,9 @@ class Extension implements ExtensionInterface
                 ->end()
                 ->scalarNode('timeout')
                     ->defaultValue(5000)
+                ->end()
+                ->scalarNode('proxy')
+                    ->defaultValue(null)
                 ->end()
             ->end()
         ;

--- a/src/WebDriver/Behat/WebDriverExtension/services/core.xml
+++ b/src/WebDriver/Behat/WebDriverExtension/services/core.xml
@@ -19,6 +19,7 @@
             <argument>%behat.webdriver.base_url%</argument>
             <argument>%behat.webdriver.browser%</argument>
             <argument>%behat.webdriver.timeout%</argument>
+            <argument>%behat.webdriver.proxy%</argument>
 
             <tag name="behat.context.initializer" />
         </service>

--- a/src/WebDriver/Capabilities.php
+++ b/src/WebDriver/Capabilities.php
@@ -132,6 +132,11 @@ class Capabilities
      */
     public $nativeEvents;
 
+    /**
+     * An ftp/http/https proxy url for the browser.
+     */
+    public $proxy;
+
     public function __construct($browserName)
     {
         $this->browserName = $browserName;
@@ -167,6 +172,15 @@ class Capabilities
             if (null !== $this->$capacityFlag) {
                 $result[$capacityFlag] = (boolean) $this->$capacityFlag;
             }
+        }
+
+        if ($this->proxy) {
+            $result['proxy'] = array(
+                'proxyType' => 'manual',
+                'httpProxy' => $this->proxy,
+                'sslProxy'  => $this->proxy,
+                'ftpProxy'  => $this->proxy
+            );
         }
 
         return $result;


### PR DESCRIPTION
This adds the possibility to run behind a proxy. For instance : 

``` yml
default:
    extensions:
        WebDriver\Behat\WebDriverExtension\Extension:
            url: http://localhost:4444/wd/hub
            base_url: http://localhost:8000/
            browser: chrome
            proxy: localhost:8001 # A proxy that will be set in the browser settings.
```
